### PR TITLE
CI: Upgrade MinGW version on windows-2019 GH runners.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,12 @@ jobs:
 
       - uses: actions/checkout@v3
 
+      # NOTE(aznashwan): starting with Golang 1.21, the windows-2019 GitHub runner's
+      # builtin MinGW version leads to DLL loading errors during runtime.
+      - name: Upgrade MinGW on Windows 2019
+        if: matrix.os == 'windows-2019'
+        run: choco upgrade mingw
+
       - name: Make
         run: |
           make build
@@ -268,6 +274,12 @@ jobs:
           echo "${{ github.workspace }}/src/github.com/kubernetes-sigs/cri-tools/build/bin/windows/amd64" >> $GITHUB_PATH
 
       - run: script/setup/install-dev-tools
+
+      # NOTE(aznashwan): starting with Golang 1.21, the windows-2019 GitHub runner's
+      # builtin MinGW version leads to DLL loading errors during runtime.
+      - name: Upgrade MinGW on Windows 2019
+        if: matrix.os == 'windows-2019'
+        run: choco upgrade mingw
 
       - name: Binaries
         env:


### PR DESCRIPTION
The default version of MinGW and GCC on the GitHub-hosted Windows 2019 runners compile fine but lead to linker errors during runtime.